### PR TITLE
Update local commands for macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,3 +32,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - normalized font sizes
 - installed yarn
 - normalized buttons' and links' styling
+- updated `package.json` commands for macOs

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ This is how to get started locally:
 
 - [Git clone this repository](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/cloning-a-repository-from-github/cloning-a-repository)
 - Run `yarn install`
-- Run `yarn run dev`
+- Run `yarn run dev` (for Windows)
+- Run `yarn run dev-mac` (for macOS)
 - [Branch out](https://git-scm.com/book/en/v2/Git-Branching-Basic-Branching-and-Merging) by following the structure `feature/add-your-branch-name` or `chore/add-your-branch-name` or `fix/add-your-branch-name` and submit your [PR](https://docs.github.com/en/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests)
 
 <br />

--- a/package.json
+++ b/package.json
@@ -3,8 +3,10 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "dev": "yarn run open-browser && next dev -p 3010",
-    "open-browser": "start http://localhost:3010",
+    "dev": "yarn run open-browser-win && next dev -p 3010",
+    "dev-mac": "yarn run open-browser-mac && next dev -p 3010",
+    "open-browser-win": "start http://localhost:3010",
+    "open-browser-mac": "open http://localhost:3010",
     "build": "next build",
     "start": "next start"
   },


### PR DESCRIPTION
|                                    Web Dev Path                                    |
| :--------------------------------------------------------------------------------: |

#### Have you updated the CHANGELOG.md file? If not, please do it.

Yes.

#### What is this change?

The project `yarn` commands to run it locally are being updated to allow opening the project automatically on macOS and Windows. The way they were set before, only Windows users would be able to run the project locally.

#### Were there any complications while making this change?

It was tricky to figure out that the `start` command only worked for Windows while `open` is the proper one for macOS.

#### How did you verify this change?

Locally by testing the project installation both on a PC and on a Mac.

#### When should this be merged?

After code review.
