### PR TITLE
Fix ButtonLink.js styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,8 +49,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - component file structure
+- ButtonLink.js styles
 
-### Changed 
+### Changed
 
 - components folder structure
 - relative to absolute imports with aliases

--- a/styles/ButtonLink.module.scss
+++ b/styles/ButtonLink.module.scss
@@ -13,10 +13,11 @@
   min-width: 16rem;
   display: inline-block;
   border: 1px solid $primary-content-color;
+  text-decoration: none !important;
   @include transition(all 0.3s ease);
 
   &:hover {
-    text-decoration: none;
+    opacity: 1 !important;
   }
 
   &.inverted-grey {

--- a/styles/ButtonLink.module.scss
+++ b/styles/ButtonLink.module.scss
@@ -13,11 +13,10 @@
   min-width: 16rem;
   display: inline-block;
   border: 1px solid $primary-content-color;
-  text-decoration: none !important;
   @include transition(all 0.3s ease);
 
   &:hover {
-    opacity: 1 !important;
+    text-decoration: none;
   }
 
   &.inverted-grey {

--- a/styles/TwoColumn.module.scss
+++ b/styles/TwoColumn.module.scss
@@ -70,15 +70,14 @@
         max-width: 39rem;
         font-size: 1.5rem;
         line-height: 1.938rem;
-      }
-
-      a {
-        text-decoration: underline;
-        text-underline-offset: 2px;
-
-        &:hover {
-          opacity: 0.6;
-          text-decoration: none;
+        a {
+          text-decoration: underline;
+          text-underline-offset: 2px;
+  
+          &:hover {
+            opacity: 0.6;
+            text-decoration: none;
+          }
         }
       }
     }


### PR DESCRIPTION
|                                    Web Dev Path                                    |
| :--------------------------------------------------------------------------------: |

#### Have you updated the CHANGELOG.md file? If not, please do it.

Yes.

#### What is this change?

The `ButtonLink.js` styles are being adjusted to remove the underline and opacity when the link added to the `TwoColumn.js` is not a button. We can see the problem on the homepage live website:

![image](https://user-images.githubusercontent.com/20016897/177087995-6aad9ecf-02d2-4302-a8f4-f482c981f75a.png)


#### Were there any complications while making this change?

Kinda, I almost fell on the `!important` hell 🤣 , but I had a brain to pick thank Gaia! Thanks, @cherylli 👩🏼‍🎤 

#### How did you verify this change?

Locally and by using the Netlify preview link.

#### When should this be merged?

After code review.
