### PR TITLE
Fix Card container tag list on blog page overflow when there are 3 or more tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,3 +93,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - removed unused function in api/register.js
 - adjusted contact form message on mobile
 - blog container and title styling
+- blog card container tags overflowing

--- a/components/containers/Card.js
+++ b/components/containers/Card.js
@@ -31,7 +31,7 @@ export default function Card({
       </h2>
       {tagList && tagList.length > 0 ? (
         <div className={styles.tagListContainer}>
-          {tagList.map((tag, i) => (
+          {tagList.slice(0, 8).map((tag, i) => (
             <Tag key={i} text={tag} />
           ))}
         </div>

--- a/styles/Card.module.scss
+++ b/styles/Card.module.scss
@@ -131,6 +131,9 @@
 
   .tagListContainer {
     display: flex;
+    flex-wrap: wrap;
+    max-height: 12rem;
+    overflow: hidden;
     gap: 0.5rem;
     margin-bottom: -1rem;
   }


### PR DESCRIPTION
|                                    Web Dev Path                                    |
| :--------------------------------------------------------------------------------: |


#### Have you updated the CHANGELOG.md file? If not, please do it.
Yes

#### What is this change?
Fix the overflowing issues of blog card tag list when there are 3 more tags
Also limit the max number of tags shown to 8 (which would be about 4 rows for longer tags)
![image](https://user-images.githubusercontent.com/6191116/221345629-bfa53fb3-d675-4f0a-bea7-d36815d7ebb9.png)

![image](https://user-images.githubusercontent.com/6191116/221345674-088cfc08-1299-4622-b523-8ea7eb34b214.png)



#### Were there any complications while making this change?
no

#### How did you verify this change?
run it locally

#### When should this be merged?
after review
