### PR TITLE
Update gitignore to include .env.development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .idea
 node_modules
 .env
+.env.development
 .DS_Store
 yarn-error.log
 .yarn/*

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 node_modules
 .env
 .env.development
+.env*.local
 .DS_Store
 yarn-error.log
 .yarn/*

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 .idea
 node_modules
 .env
-.env.development
 .env*.local
 .DS_Store
 yarn-error.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Updated contents in home,about, and contact.
 - Added Satoshi to 'about us'
 - Added Lucas to 'about us'
+- Added .env.development to .gitignore
 
 ### Fixed
 


### PR DESCRIPTION
|                                    Web Dev Path                                    |
| :--------------------------------------------------------------------------------: |
|  |

#### Have you updated the CHANGELOG.md file? If not, please do it.
Yes

#### What is this change?
Add `.env*.local` to `.gitignore` to allow developers to have an extra sets of environment variables for testing

https://nextjs.org/docs/pages/building-your-application/configuring/environment-variables

next.js will load and prioritize .env.development(.local) over .env /.env.local when `yarn dev` is run

#### Were there any complications while making this change?
No

#### How did you verify this change?
Run locally

#### When should this be merged?
After review