### PR TITLE
Fixing contact form message position desktop and mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,3 +136,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed search funcitionality on blog page
 - Fixed dev.to images not showing due to them changing image host
 - Fixed styling issue on nav links
+- Fixed contact form message position

--- a/styles/pages/contactStyles.js
+++ b/styles/pages/contactStyles.js
@@ -100,22 +100,14 @@ const YellowColon = styled.img`
 `;
 
 const ResponseMessage = styled.div`
-  position: absolute;
-  right: 8%;
+  position: unset;
   bottom: -5%;
-  margin: auto;
+  padding: 0 2rem;
 
   ${props => css`
-    @media (min-width: ${props.theme.breakpoints.mobile}) {
-      position: unset;
+    @media (min-width: ${props.theme.breakpoints.tablet}) {
+      position: absolute;
       margin-top: 1rem;
-      padding: 0 2rem;
-    }
-  `}
-
-  ${props => css`
-    @media (min-width: ${props.theme.breakpoints.smMobile}) {
-      max-width: fit-content;
     }
   `}
 `;


### PR DESCRIPTION
|                                    Web Dev Path                                    |
| :--------------------------------------------------------------------------------: |
| [**221**](https://github.com/MarianaSouza/web-dev-path/issues/221) |

#### Have you updated the CHANGELOG.md file? If not, please do it.

Yes.

#### What is this change?

We're fixing the contact form response position that was not being displayed on desktop and caused a weird form shift.

#### Were there any complications while making this change?

No.

#### How to replicate the issue?

On the live site, go to the form and send a message. 

#### If necessary, please describe how to test the new feature or fix.

Run this branch locally and try to send a message using our contact form. The message should appear correctly either on desktop or mobile:

<img width="1795" alt="Screenshot 2024-08-16 at 4 44 51 PM" src="https://github.com/user-attachments/assets/451a877f-ae02-4d6c-a290-56b61757bec5">

<img width="426" alt="Screenshot 2024-08-16 at 4 45 13 PM" src="https://github.com/user-attachments/assets/ee427055-5b5e-4d43-af88-e6c3234892e4">


#### When should this be merged?

After review
