### PR TITLE
Update next.config.js to allow images from any dev.to subdomain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,3 +137,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed dev.to images not showing due to them changing image host
 - Fixed styling issue on nav links
 - Fixed contact form message position
+- Fixed blog images not loading due to dev.to changing image host (sub)domain

--- a/next.config.js
+++ b/next.config.js
@@ -24,7 +24,7 @@ module.exports = withPWA({
       },
       {
         protocol: 'https',
-        hostname: 'media.dev.to',
+        hostname: '*.dev.to',
       },
     ],
   },


### PR DESCRIPTION
|                                    Web Dev Path                                    |
| :--------------------------------------------------------------------------------: |
| closing #223 |
 

#### Have you updated the CHANGELOG.md file? If not, please do it.
Yes

#### What is this change? 
It looks like dev.to has moved all the cover images to `media2.dev.to` other images are still in `media.dev.to`. `next.config.js` has been updated to allow images from any dev.to subdomain

#### Were there any complications while making this change?
no

#### How to replicate the issue?

#### If necessary, please describe how to test the new feature or fix.

#### When should this be merged?
as soon as possible after review