### PR TITLE
Fix Empty blog category

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,3 +138,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed styling issue on nav links
 - Fixed contact form message position
 - Fixed blog images not loading due to dev.to changing image host (sub)domain
+- Fixed empty blog category by using per_page parameter

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ This is how to get started locally:
 
 ## Developer Note
 
-- The Dev.to API has a limit of 1000 posts per response. If we exceed this limit by writing more than 1000 posts, we will need to update the getStaticProps on `/pages/blog`. For more details, refer to the [API documentation](https://developers.forem.com/api/v1#tag/articles/operation/getArticles).
+- The Dev.to API has a 30 posts limit by default and we updated it to 1000. If we need to fetch more posts, we will need to update the getStaticProps on `/pages/blog`. For more details, refer to the [API documentation](https://developers.forem.com/api/v1#tag/articles/operation/getArticles).
 
 <br />
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ This is how to get started locally:
 
 <br />
 
+## Developer Note
+
+- The Dev.to API has a limit of 1000 posts per response. If we exceed this limit by writing more than 1000 posts, we will need to update the getStaticProps on `/pages/blog`. For more details, refer to the [API documentation](https://developers.forem.com/api/v1#tag/articles/operation/getArticles).
+
+<br />
+
 ## License
 
 This project is licensed under the GNU General Public License v3.0 - see the [LICENSE](LICENSE) file for details.

--- a/pages/blog/index.js
+++ b/pages/blog/index.js
@@ -48,7 +48,8 @@ export default function Blog({ posts }) {
 }
 
 export async function getStaticProps() {
-  const res = await fetch('https://dev.to/api/articles?username=wdp');
+  const PER_PAGE = 1000
+  const res = await fetch(`https://dev.to/api/articles?username=wdp&per_page=${PER_PAGE}`);
   const posts = await res.json();
 
   return {


### PR DESCRIPTION
|                                    Web Dev Path                                    |
| :--------------------------------------------------------------------------------: |
| [**225**](https://github.com/MarianaSouza/web-dev-path/issues/225) |

#### Have you updated the CHANGELOG.md file? If not, please do it.
I did
#### What is this change?
Add per_page parameter to the fetch call to get all the blog posts.
#### Were there any complications while making this change?
No complications
#### If necessary, please describe how to test the new feature or fix.
Go to the blog page and check if the Next.js section has two posts
![Screenshot from 2024-11-23 10-50-50](https://github.com/user-attachments/assets/b6bc3867-982b-4f50-bbe8-b104c6ca9bf2)

#### When should this be merged?
After reviews
