### PR TITLE
Update Husky script for the newer version

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,7 +1,3 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 exec >/dev/tty 2>&1
 
 npx lint-staged
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,3 +152,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Updated outdated dependencies
 
 ### Fixed
+- Updated husky script to avoid warning


### PR DESCRIPTION
|                                    Web Dev Path                                    |
| :--------------------------------------------------------------------------------: |
| [**240**](https://github.com/MarianaSouza/web-dev-path/issues/issueNumber) |

#### Have you updated the CHANGELOG.md file? If not, please do it.
I did.
#### What is this change?
Updated the script as the warning suggested
#### Were there any complications while making this change?
No
#### How to replicate the issue?
Commit anything on main branch and you will see the warning from Husky. 

```
husky - DEPRECATED

Please remove the following two lines from .husky/pre-commit:

#!/usr/bin/env sh
. "$(dirname -- "$0")/_/husky.sh"

They WILL FAIL in v10.0.0
```

#### If necessary, please describe how to test the new feature or fix.
Commit anything on this branch and you will not see the warning anymore.


#### When should this be merged?
After review