### PR TITLE
Refactor/to scss title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,6 +156,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Updated husky script to avoid warning
 - Resolved incorrect meta tag rendering for nested routes
+- Prevent horizontal page scroll caused by overflowing long titles
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -175,6 +175,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - Row
   - Container
   - Wrapper
+  - Title
   - Extracted :root from themes.scss to globals.scss
 - Updated ContactUsForm's checkbox wrapper from div to label to enhance its accessibility
 - Updated SearchInput width to 100% for better styling

--- a/components/snippets/Title.js
+++ b/components/snippets/Title.js
@@ -1,12 +1,5 @@
-import styled from 'styled-components';
-
-export const StyledTitle = styled.h2`
-  align-self: flex-start;
-  margin: '0 auto 1rem';
-`;
-
 const Title = ({ title }) => {
-  return <StyledTitle>{title}</StyledTitle>;
+  return <h2>{title}</h2>;
 };
 
 export default Title;

--- a/components/snippets/Title.js
+++ b/components/snippets/Title.js
@@ -1,5 +1,7 @@
+const styleProp = { overflowWrap: 'break-word', hyphens: 'auto' };
+
 const Title = ({ title }) => {
-  return <h2>{title}</h2>;
+  return <h2 style={styleProp}>{title}</h2>;
 };
 
 export default Title;

--- a/pages/blog/index.js
+++ b/pages/blog/index.js
@@ -29,7 +29,7 @@ export default function Blog({ posts }) {
     <>
       <Container>
         <BlogSearch>
-          <Title blogTitle title={!searchTerm && 'Latest Posts'} />
+          <Title title={!searchTerm && 'Latest Posts'} />
           <SearchBar setSearchTerm={setSearchTerm} />
         </BlogSearch>
       </Container>
@@ -48,8 +48,10 @@ export default function Blog({ posts }) {
 }
 
 export async function getStaticProps() {
-  const PER_PAGE = 1000
-  const res = await fetch(`https://dev.to/api/articles?username=wdp&per_page=${PER_PAGE}`);
+  const PER_PAGE = 1000;
+  const res = await fetch(
+    `https://dev.to/api/articles?username=wdp&per_page=${PER_PAGE}`,
+  );
   const posts = await res.json();
 
   return {


### PR DESCRIPTION
|                                    Web Dev Path                                    |
| :--------------------------------------------------------------------------------: |
| [**238**](https://github.com/Web-Dev-Path/web-dev-path/issues/238) |

#### Have you updated the CHANGELOG.md file? If not, please do it.

Yes

#### What is this change?

- Remove redundant style-components rules
- Prevent inappropriate horizontal scroll caused by overflowing long titles
- Delete unused `blogTitle` prop in `blog/index.js`

#### Were there any complications while making this change?

No

#### How to replicate the issue?

Steps to replicate the inappropriate horizontal scroll issue:
1. Go to the live site’s [blog page](https://www.webdevpath.co/blog).
2. Switch to the mobile view.
3. Click a long tag, for instance the `productmanagement` tag.

<img width="1920" height="1033" alt="overflowing-title-webdev" src="https://github.com/user-attachments/assets/5a48e6dd-cd8d-4ce2-9d17-cd90ee8914db" />

#### If necessary, please describe how to test the new feature or fix.

Compare the `<h2>` titles of the “/blog/*” and “/about” pages on the `main` and `refactor/to-scss-snippets-title` branches. The two should have the same style. Additionally, overflowing titles of the PR branch should auto-wrap to prevent inappropriate horizontal scrolling.

<img width="1920" height="980" alt="blog-page-title-webdev" src="https://github.com/user-attachments/assets/ec88d5a4-d71b-465b-bb41-cf93125b8354" />

#### When should this be merged?

After three approved reviews.